### PR TITLE
accept peerDep react-router v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "standard": "^8.5.0"
   },
   "peerDependencies": {
-    "react-router": "^3.0.0"
+    "react-router": "^2.0.0 || ^3.0.0"
   },
   "ava": {
     "require": [


### PR DESCRIPTION
same API in v2 and v3

currently I'm getting errors while shrinkwrapping as an app I have uses react-router@^2 instead of 3